### PR TITLE
Partition the mesh uniformly along a co-ordinate axis with parRSB

### DIFF
--- a/3rd_party/nek5000/core/reader_par.f
+++ b/3rd_party/nek5000/core/reader_par.f
@@ -916,7 +916,7 @@ c set partitioner options
       else if (index(c_out,'RCB').eq.1) then
          fluid_partitioner=1
       else if (index(c_out,'RIB').eq.1) then
-         solid_partitioner=2
+         fluid_partitioner=2
       else if (index(c_out,'UNIFORMX').eq.1) then
          fluid_partitioner=3
       else if (index(c_out,'UNIFORMY').eq.1) then

--- a/3rd_party/nek5000/core/reader_par.f
+++ b/3rd_party/nek5000/core/reader_par.f
@@ -891,8 +891,21 @@ c set partitioner options
       else if (index(c_out,'RCB').eq.1) then
          fluid_partitioner=1
          solid_partitioner=1
+      else if (index(c_out,'RIB').eq.1) then
+         fluid_partitioner=2
+         solid_partitioner=2
+      else if (index(c_out,'UNIFORMX').eq.1) then
+         fluid_partitioner=3
+         solid_partitioner=3
+      else if (index(c_out,'UNIFORMY').eq.1) then
+         fluid_partitioner=4
+         solid_partitioner=4
+      else if (index(c_out,'UNIFORMZ').eq.1) then
+         fluid_partitioner=5
+         solid_partitioner=5
       else if (index(c_out,'METIS').eq.1) then
          fluid_partitioner=8
+         solid_partitioner=8
       endif
 
 c set partitioner options
@@ -902,6 +915,14 @@ c set partitioner options
          fluid_partitioner=0
       else if (index(c_out,'RCB').eq.1) then
          fluid_partitioner=1
+      else if (index(c_out,'RIB').eq.1) then
+         solid_partitioner=2
+      else if (index(c_out,'UNIFORMX').eq.1) then
+         fluid_partitioner=3
+      else if (index(c_out,'UNIFORMY').eq.1) then
+         fluid_partitioner=4
+      else if (index(c_out,'UNIFORMZ').eq.1) then
+         fluid_partitioner=5
       else if (index(c_out,'METIS').eq.1) then
          fluid_partitioner=8
       endif
@@ -913,6 +934,14 @@ c set partitioner options
          solid_partitioner=0
       else if (index(c_out,'RCB').eq.1) then
          solid_partitioner=1
+      else if (index(c_out,'RIB').eq.1) then
+         solid_partitioner=2
+      else if (index(c_out,'UNIFORMX').eq.1) then
+         solid_partitioner=3
+      else if (index(c_out,'UNIFORMY').eq.1) then
+         solid_partitioner=4
+      else if (index(c_out,'UNIFORMZ').eq.1) then
+         solid_partitioner=5
       else if (index(c_out,'METIS').eq.1) then
          solid_partitioner=8
       endif

--- a/3rd_party/nek5000_parRSB/src/parrsb-impl.h
+++ b/3rd_party/nek5000_parRSB/src/parrsb-impl.h
@@ -35,6 +35,8 @@ int rcb(struct array *elements, size_t unit_size, int ndim, struct comm *c,
         buffer *bfr);
 int rib(struct array *elements, size_t unit_size, int ndim, struct comm *c,
         buffer *bfr);
+int uniform(struct array *elements, size_t unit_size, int dim, struct comm *c,
+        buffer *bfr);
 
 //------------------------------------------------------------------------------
 // RSB.

--- a/3rd_party/nek5000_parRSB/src/parrsb.c
+++ b/3rd_party/nek5000_parRSB/src/parrsb.c
@@ -276,6 +276,9 @@ static void parrsb_part_mesh_v0(int *part, const long long *const vtx,
     case 0: rsb(&elist, nv, options, comms, bfr); break;
     case 1: rcb(&elist, esize, ndim, &ca, bfr); break;
     case 2: rib(&elist, esize, ndim, &ca, bfr); break;
+    case 3:
+    case 4:
+    case 5: uniform(&elist, esize, options->partitioner - 3, &ca, bfr); break;
     default: break;
     }
   }

--- a/3rd_party/nek5000_parRSB/src/uniform.c
+++ b/3rd_party/nek5000_parRSB/src/uniform.c
@@ -1,0 +1,33 @@
+
+#include "parrsb-impl.h"
+#include "sort.h"
+
+int uniform(struct array *a, size_t unit_size, int dim, struct comm *c, buffer *bfr) {
+  if (unit_size == sizeof(struct rcb_element)) {
+    switch (dim) {
+    case 0:
+      parallel_sort(struct rcb_element, a, coord[0], gs_double, 0, 1, c, bfr);
+      break;
+    case 1:
+      parallel_sort(struct rcb_element, a, coord[1], gs_double, 0, 1, c, bfr);
+      break;
+    case 2:
+      parallel_sort(struct rcb_element, a, coord[2], gs_double, 0, 1, c, bfr);
+      break;
+    default: break;
+    }
+  } else if (unit_size == sizeof(struct rsb_element)) {
+    switch (dim) {
+    case 0:
+      parallel_sort(struct rsb_element, a, coord[0], gs_double, 0, 1, c, bfr);
+      break;
+    case 1:
+      parallel_sort(struct rsb_element, a, coord[1], gs_double, 0, 1, c, bfr);
+      break;
+    case 2:
+      parallel_sort(struct rsb_element, a, coord[2], gs_double, 0, 1, c, bfr);
+      break;
+    default: break;
+    }
+  }
+}

--- a/src/core/io/par.cpp
+++ b/src/core/io/par.cpp
@@ -2088,6 +2088,15 @@ void parseGeneralSection(const int rank, setupAide &options, inipp::Ini *ini)
   }
 }
 
+static std::vector<std::string> partitioners {
+  {"rcb+rsb"}, // Ideally this should just be `rsb` for consistency.
+  {"rcb"},
+  {"rib"},
+  {"uniformx"},
+  {"uniformy"},
+  {"uniformz"},
+};
+
 void parseMeshSection(const int rank, setupAide &options, inipp::Ini *ini)
 {
   if (ini->sections.count("mesh")) {
@@ -2126,7 +2135,8 @@ void parseMeshSection(const int rank, setupAide &options, inipp::Ini *ini)
 
     std::string meshPartitioner;
     if (ini->extract("mesh", "partitioner", meshPartitioner)) {
-      if (meshPartitioner != "rcb" && meshPartitioner != "rcb+rsb") {
+      auto it = std::find(partitioners.begin(), partitioners.end(), meshPartitioner);
+      if (it == partitioners.end()) {
         std::ostringstream error;
         error << "Could not parse mesh::partitioner = " << meshPartitioner;
         append_error(error.str());

--- a/src/nekInterface/nekInterfaceAdapter.cpp
+++ b/src/nekInterface/nekInterfaceAdapter.cpp
@@ -1051,9 +1051,17 @@ int setup(int numberActiveFields)
 
   std::string velocitySolver;
 
-  int meshPartType = 0; // RCB+RSB
+  int meshPartType = 0; // RSB
   if (options->compareArgs("MESH PARTITIONER", "rcb")) {
     meshPartType = 1;
+  } else if (options->compareArgs("MESH PARTITIONER", "rib")) {
+    meshPartType = 2;
+  } else if (options->compareArgs("MESH PARTITIONER", "uniformx")) {
+    meshPartType = 3;
+  } else if (options->compareArgs("MESH PARTITIONER", "uniformy")) {
+    meshPartType = 4;
+  } else if (options->compareArgs("MESH PARTITIONER", "uniformz")) {
+    meshPartType = 5;
   }
 
   double meshConTol = 0.2;


### PR DESCRIPTION
Use the new partitioners on an uniform (or an extruded mesh) as below:

```sh
[MESH]
# This PR adds `uniformx`, `uniformy` and `uniformz`
partitioner = uniformz
```

The number of layers in the given direction should ideally be a multiple of the
number of processors.