### PR TITLE
Uniform mesh partitioner and SmartRedis scalability

### DIFF
--- a/3rd_party/nek5000/core/reader_par.f
+++ b/3rd_party/nek5000/core/reader_par.f
@@ -891,8 +891,21 @@ c set partitioner options
       else if (index(c_out,'RCB').eq.1) then
          fluid_partitioner=1
          solid_partitioner=1
+      else if (index(c_out,'RIB').eq.1) then
+         fluid_partitioner=2
+         solid_partitioner=2
+      else if (index(c_out,'UNIFORMX').eq.1) then
+         fluid_partitioner=3
+         solid_partitioner=3
+      else if (index(c_out,'UNIFORMY').eq.1) then
+         fluid_partitioner=4
+         solid_partitioner=4
+      else if (index(c_out,'UNIFORMZ').eq.1) then
+         fluid_partitioner=5
+         solid_partitioner=5
       else if (index(c_out,'METIS').eq.1) then
          fluid_partitioner=8
+         solid_partitioner=8
       endif
 
 c set partitioner options
@@ -902,6 +915,14 @@ c set partitioner options
          fluid_partitioner=0
       else if (index(c_out,'RCB').eq.1) then
          fluid_partitioner=1
+      else if (index(c_out,'RIB').eq.1) then
+         solid_partitioner=2
+      else if (index(c_out,'UNIFORMX').eq.1) then
+         fluid_partitioner=3
+      else if (index(c_out,'UNIFORMY').eq.1) then
+         fluid_partitioner=4
+      else if (index(c_out,'UNIFORMZ').eq.1) then
+         fluid_partitioner=5
       else if (index(c_out,'METIS').eq.1) then
          fluid_partitioner=8
       endif
@@ -913,6 +934,14 @@ c set partitioner options
          solid_partitioner=0
       else if (index(c_out,'RCB').eq.1) then
          solid_partitioner=1
+      else if (index(c_out,'RIB').eq.1) then
+         solid_partitioner=2
+      else if (index(c_out,'UNIFORMX').eq.1) then
+         solid_partitioner=3
+      else if (index(c_out,'UNIFORMY').eq.1) then
+         solid_partitioner=4
+      else if (index(c_out,'UNIFORMZ').eq.1) then
+         solid_partitioner=5
       else if (index(c_out,'METIS').eq.1) then
          solid_partitioner=8
       endif

--- a/3rd_party/nek5000_parRSB/src/parrsb-impl.h
+++ b/3rd_party/nek5000_parRSB/src/parrsb-impl.h
@@ -35,6 +35,8 @@ int rcb(struct array *elements, size_t unit_size, int ndim, struct comm *c,
         buffer *bfr);
 int rib(struct array *elements, size_t unit_size, int ndim, struct comm *c,
         buffer *bfr);
+int uniform(struct array *elements, size_t unit_size, int dim, struct comm *c,
+        buffer *bfr);
 
 //------------------------------------------------------------------------------
 // RSB.

--- a/3rd_party/nek5000_parRSB/src/parrsb.c
+++ b/3rd_party/nek5000_parRSB/src/parrsb.c
@@ -276,6 +276,9 @@ static void parrsb_part_mesh_v0(int *part, const long long *const vtx,
     case 0: rsb(&elist, nv, options, comms, bfr); break;
     case 1: rcb(&elist, esize, ndim, &ca, bfr); break;
     case 2: rib(&elist, esize, ndim, &ca, bfr); break;
+    case 3:
+    case 4:
+    case 5: uniform(&elist, esize, options->partitioner - 3, &ca, bfr); break;
     default: break;
     }
   }

--- a/3rd_party/nek5000_parRSB/src/uniform.c
+++ b/3rd_party/nek5000_parRSB/src/uniform.c
@@ -1,0 +1,33 @@
+
+#include "parrsb-impl.h"
+#include "sort.h"
+
+int uniform(struct array *a, size_t unit_size, int dim, struct comm *c, buffer *bfr) {
+  if (unit_size == sizeof(struct rcb_element)) {
+    switch (dim) {
+    case 0:
+      parallel_sort(struct rcb_element, a, coord[0], gs_double, 0, 1, c, bfr);
+      break;
+    case 1:
+      parallel_sort(struct rcb_element, a, coord[1], gs_double, 0, 1, c, bfr);
+      break;
+    case 2:
+      parallel_sort(struct rcb_element, a, coord[2], gs_double, 0, 1, c, bfr);
+      break;
+    default: break;
+    }
+  } else if (unit_size == sizeof(struct rsb_element)) {
+    switch (dim) {
+    case 0:
+      parallel_sort(struct rsb_element, a, coord[0], gs_double, 0, 1, c, bfr);
+      break;
+    case 1:
+      parallel_sort(struct rsb_element, a, coord[1], gs_double, 0, 1, c, bfr);
+      break;
+    case 2:
+      parallel_sort(struct rsb_element, a, coord[2], gs_double, 0, 1, c, bfr);
+      break;
+    default: break;
+    }
+  }
+}

--- a/examples/turbChannel_smartredis/README.md
+++ b/examples/turbChannel_smartredis/README.md
@@ -89,5 +89,5 @@ The script generate the config file for the workflow (`ssim_config.yaml`) and th
 The outputs of the nekRS and trainer will be within the `./nekRS` directory created at runtime.
 
 ## Known Issues and Tips
-- The clustered deployment requires at least 3 nodes for training and 2 nodes for inference since it deploys each component on a distinct set of nodes. Also note that the SmartSim database can be run on a single node or sharded across multiple nodes (>=3).
+- The clustered deployment requires at least 3 nodes for training and 2 nodes for inference since it deploys each component on a distinct set of nodes. Also note that the SmartSim database can be run on a single node or sharded across 3 or more nodes (sharding across 2 nodes is not allowed). 
 - On Aurora, inference can only be run on the CPU. nekRS will still run on the GPU, but model inference will be executed on the host. This is due to a limitation of RedisAI on Intel hardware.

--- a/examples/turbChannel_smartredis/clean
+++ b/examples/turbChannel_smartredis/clean
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 rm -r nekRS-ML outputs
-rm affinity_* ssim_config.yaml turbChannel.par turbChannel.udf run.sh
+rm affinity_* ssim_config.yaml 
+rm turbChannel.par turbChannel.udf turbChannel.box run.sh
 

--- a/examples/turbChannel_smartredis/ssimrun_aurora
+++ b/examples/turbChannel_smartredis/ssimrun_aurora
@@ -98,11 +98,13 @@ echo "# Run config" >> $CFILE
 echo "run_args:" >> $CFILE
 echo "    nodes: ${qnodes}" >> $CFILE
 if [ ${DEPLOYMENT} == "colocated"  ]; then
-  SIM_PROCS=$(( nodes * SIM_RANKS_PER_NODE ))
-  TRAIN_PROCS=$(( nodes * TRAIN_RANKS_PER_NODE ))
+  SIM_NODES=$nodes
+  TRAIN_NODES=$nodes
+  SIM_PROCS=$(( SIM_NODES * SIM_RANKS_PER_NODE ))
+  TRAIN_PROCS=$(( TRAIN_NODES * TRAIN_RANKS_PER_NODE ))
   echo "    db_nodes: 1" >> $CFILE
-  echo "    sim_nodes: ${nodes}" >> $CFILE
-  echo "    ml_nodes: ${nodes}" >> $CFILE
+  echo "    sim_nodes: ${SIM_NODES}" >> $CFILE
+  echo "    ml_nodes: ${SIM_NODES}" >> $CFILE
   echo "    simprocs: ${SIM_PROCS}" >> $CFILE
   echo "    simprocs_pn: ${SIM_RANKS_PER_NODE}" >> $CFILE
   echo "    mlprocs: ${TRAIN_PROCS}" >> $CFILE
@@ -168,6 +170,21 @@ elif [ ${ML_TASK} == "inference"  ]; then
   echo "    copy_files: []" >> $CFILE
   echo "    link_files: []" >> $CFILE
 fi
+
+#--------------------------------------
+# Update the .par file with the ML options
+PFILE=${case}.par
+echo "" >> $PFILE
+echo "[ML]" >> $PFILE
+echo "ssimDeployment = ${DEPLOYMENT}" >> $PFILE
+echo "ssimDbNodes = ${DB_NODES}" >> $PFILE
+
+#--------------------------------------
+# Update the .box file to increase the mesh size linearly with the number of nodes
+NX=$(( 36*SIM_NODES ))
+NZ=$(( 18*SIM_NODES ))
+sed -i "s/NX/${NX}/g" ${case}.box
+sed -i "s/NZ/${NZ}/g" ${case}.box
 
 #--------------------------------------
 # Generate the run script

--- a/examples/turbChannel_smartredis/ssimrun_aurora
+++ b/examples/turbChannel_smartredis/ssimrun_aurora
@@ -6,8 +6,8 @@ set -e
 : ${NEKRS_GPU_MPI:=0}
 : ${NEKRS_BACKEND:="dpcpp"}
 : ${RANKS_FOR_BUILD:=12}
-: ${SIM_RANKS_PER_NODE:=4}
-: ${TRAIN_RANKS_PER_NODE:=4}
+: ${SIM_RANKS_PER_NODE:=6}
+: ${TRAIN_RANKS_PER_NODE:=6}
 : ${DEPLOYMENT:="colocated"}
 : ${ML_TASK:="train"}
 : ${DB_NODES:=1}
@@ -183,6 +183,7 @@ echo "ssimDbNodes = ${DB_NODES}" >> $PFILE
 # Update the .box file to increase the mesh size linearly with the number of nodes
 NX=$(( 36*SIM_NODES ))
 NZ=$(( 18*SIM_NODES ))
+cp ${case}_1node.box ${case}.box
 sed -i "s/NX/${NX}/g" ${case}.box
 sed -i "s/NZ/${NZ}/g" ${case}.box
 

--- a/examples/turbChannel_smartredis/trainer.py
+++ b/examples/turbChannel_smartredis/trainer.py
@@ -290,13 +290,11 @@ def main():
 
     # Instantiate the NN model and optimizer
     model = NeuralNetwork(inputDim=ndIn, outputDim=ndOut, numNeurons=nNeurons)
+    model = DDP(model) 
     if (args.device != 'cpu'):
         model.to(args.device)
     optimizer = optim.Adam(model.parameters(), lr=learning_rate*size)
     
-    # Wrap model with DDP
-    model = DDP(model) 
-
     # Training setup and variable initialization
     istep = -1 # initialize the simulation step number to -1
     step_list = [] # initialize an empty list containing all the steps sent

--- a/examples/turbChannel_smartredis/turbChannel.box
+++ b/examples/turbChannel_smartredis/turbChannel.box
@@ -2,7 +2,7 @@
 1                      number of fields
 #=======================================================================
 Box
--36  -16  -18                                    nelx,nely,nelz for Box
+-72  -16  -36                                    nelx,nely,nelz for Box
 0 1 1.                                          x0,x1,gain
 0 1 1.                                          y0,y1,gain
 0 1 1.                                          z0,z1,gain

--- a/examples/turbChannel_smartredis/turbChannel_1node.box
+++ b/examples/turbChannel_smartredis/turbChannel_1node.box
@@ -2,7 +2,7 @@
 1                      number of fields
 #=======================================================================
 Box
--72  -16  -36                                    nelx,nely,nelz for Box
+-NX  -16  -NZ                                    nelx,nely,nelz for Box
 0 1 1.                                          x0,x1,gain
 0 1 1.                                          y0,y1,gain
 0 1 1.                                          z0,z1,gain

--- a/examples/turbChannel_smartredis/turbChannel_inference.par
+++ b/examples/turbChannel_smartredis/turbChannel_inference.par
@@ -31,4 +31,4 @@ zLength = 3.141592653
 betaY = 2.2
 
 [MESH]
-partitioner=rcb
+partitioner = uniformz

--- a/examples/turbChannel_smartredis/turbChannel_train.par
+++ b/examples/turbChannel_smartredis/turbChannel_train.par
@@ -30,5 +30,5 @@ zLength = 3.141592653
 betaY = 2.2
 
 [MESH]
-partitioner=rcb
+partitioner = uniformz
 

--- a/examples/turbChannel_smartredis/turbChannel_train.udf
+++ b/examples/turbChannel_smartredis/turbChannel_train.udf
@@ -105,7 +105,6 @@ void UDF_ExecuteStep(double time, int tstep)
   // Every time step check if ML training says it is time to quit
   int exit_val = smartredis::check_run();
   if (exit_val==0) {
-    //platform->options.setArgs("END TIME",to_string_f(-10.0));
     nekrs::setEndTime(-10.0);
     nekrs::forceLastStep();
   }

--- a/src/nekInterface/nekInterfaceAdapter.cpp
+++ b/src/nekInterface/nekInterfaceAdapter.cpp
@@ -970,9 +970,17 @@ int setup(int numberActiveFields)
 
   std::string velocitySolver;
 
-  int meshPartType = 0; // RCB+RSB
+  int meshPartType = 0; // RSB
   if (options->compareArgs("MESH PARTITIONER", "rcb")) {
     meshPartType = 1;
+  } else if (options->compareArgs("MESH PARTITIONER", "rib")) {
+    meshPartType = 2;
+  } else if (options->compareArgs("MESH PARTITIONER", "uniformx")) {
+    meshPartType = 3;
+  } else if (options->compareArgs("MESH PARTITIONER", "uniformy")) {
+    meshPartType = 4;
+  } else if (options->compareArgs("MESH PARTITIONER", "uniformz")) {
+    meshPartType = 5;
   }
 
   double meshConTol = 0.2;

--- a/src/plugins/smartRedis.hpp
+++ b/src/plugins/smartRedis.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 struct smartredis_data {
+  std::string deployment; // deployment type for DB
   int npts_per_tensor; // number of points (samples) per tensor being sent to DB
   int num_tot_tensors; // number of total tensors being sent to all DB
   int num_db_tensors; // number of tensors being sent to each DB
@@ -33,9 +34,6 @@ namespace smartredis
   void init_wallModel_train(nrs_t *nrs);
   void put_wallModel_data(nrs_t *nrs, int tstep);
   void run_wallModel(nrs_t *nrs, int tstep);
-  void init_velNpres_train(nrs_t *nrs);
-  void put_velNpres_data(nrs_t *nrs, int tstep);
-  void run_pressure_model(nrs_t *nrs, int tstep);
 }
 
 #endif


### PR DESCRIPTION
This PR addresses the following issues: 

1. Thanks to @thilinarmtb, nekRS can partition grids in a uniform way along all 3 coordinates. This means nekRS can now be forced to split the mesh along particular directions. This works also if the number of elements is not a multiple of the number of ranks.
2. Some hard-coded parameters in the SmartRedis plugin are now readable from the .par file, allowing the colocated and clustered deployments to scale to arbitrary size.
3. Other fixes and features added to `turbChannel_smartredis` to enable multi-node weak scaling.
