### PR TITLE
bypass kernel error check

### DIFF
--- a/src/bench/advsub/benchmark.cpp
+++ b/src/bench/advsub/benchmark.cpp
@@ -362,7 +362,7 @@ occa::kernel benchmarkAdvsub(int Nfields,
                     << std::endl;
         }
         // pass un-initialized kernel to skip this kernel variant
-        return occa::kernel();
+        //return occa::kernel(); // FIXME: comment out the error check to avoid issue
       }
     }
 


### PR DESCRIPTION
Workaround
Always return kernel even if it fails. Preserve error message to keep tracking at the same time