### PR TITLE
Add h refine capability into NekRS

### DIFF
--- a/src/core/io/par.cpp
+++ b/src/core/io/par.cpp
@@ -190,6 +190,7 @@ static std::vector<std::string> meshKeys = {
     {"connectivitytol"},
     {"boundaryidmapV"},
     {"boundaryidmap"},
+    {"refine"},
 };
 
 static std::vector<std::string> velocityKeys = {
@@ -2094,6 +2095,22 @@ void parseMeshSection(const int rank, setupAide &options, inipp::Ini *ini)
     std::string meshFile;
     if (ini->extract("mesh", "file", meshFile)) {
       options.setArgs("MESH FILE", meshFile);
+    }
+
+    std::string p_refineSchedule;
+    if (ini->extract("mesh", "refine", p_refineSchedule)) {
+      options.setArgs("MESH REFINEMENT SCHEDULE", p_refineSchedule);
+
+      int ncut = 1;
+      for (auto &&s : serializeString(p_refineSchedule, ',')) {
+        ncut *= std::stoi(s);
+      }
+      if (ncut > 1) {
+        int ndim = 3;
+        int scale = static_cast<int>(std::pow(ncut, ndim));
+        options.setArgs("MESH REFINEMENT NCUT", std::to_string(ncut));
+        options.setArgs("MESH REFINEMENT SCALE", std::to_string(scale));
+      }
     }
 
     parseLinearSolver(rank, options, ini, "mesh");

--- a/src/elliptic/registerEllipticKernels.cpp
+++ b/src/elliptic/registerEllipticKernels.cpp
@@ -147,6 +147,14 @@ void registerEllipticKernels(std::string section, int poissonEquation)
   int nelgt, nelgv;
   const std::string meshFile = platform->options.getArgs("MESH FILE");
   re2::nelg(meshFile, nelgt, nelgv, platform->comm.mpiComm);
+  {
+    int nscale = 1;
+    platform->options.getArgs("MESH REFINEMENT SCALE", nscale);
+    if (nscale > 1) {
+      nelgt *= nscale;
+      nelgv *= nscale;
+    }
+  }
   const int NelemBenchmark = nelgv / platform->comm.mpiCommSize;
   bool verbose = platform->options.compareArgs("VERBOSE", "TRUE");
   const int verbosity = verbose ? 2 : 1;

--- a/src/elliptic/registerEllipticPreconditionerKernels.cpp
+++ b/src/elliptic/registerEllipticPreconditionerKernels.cpp
@@ -1,7 +1,7 @@
 #include <compileKernels.hpp>
 #include "benchmarkFDM.hpp"
 #include "benchmarkAx.hpp"
-#include "ellipticPrecon.h" 
+#include "ellipticPrecon.h"
 
 #include "re2Reader.hpp"
 
@@ -34,6 +34,14 @@ void registerAxKernels(const std::string &section, int N, int poissonEquation)
   int nelgt, nelgv;
   const std::string meshFile = platform->options.getArgs("MESH FILE");
   re2::nelg(meshFile, nelgt, nelgv, platform->comm.mpiComm);
+  {
+    int nscale = 1;
+    platform->options.getArgs("MESH REFINEMENT SCALE", nscale);
+    if (nscale > 1) {
+      nelgt *= nscale;
+      nelgv *= nscale;
+    }
+  }
   const int NelemBenchmark = nelgv / platform->comm.mpiCommSize;
 
   occa::properties AxKernelInfo = kernelInfo;
@@ -166,7 +174,7 @@ void registerSchwarzKernels(const std::string &section, int N)
 
   const bool serial = platform->serial;
   const std::string oklpath = getenv("NEKRS_KERNEL_DIR") + std::string("/elliptic/");
- 
+
   std::string fileName, kernelName;
   const std::string extension = serial ? ".c" : ".okl";
 
@@ -187,6 +195,14 @@ void registerSchwarzKernels(const std::string &section, int N)
     int nelgt, nelgv;
     const std::string meshFile = platform->options.getArgs("MESH FILE");
     re2::nelg(meshFile, nelgt, nelgv, platform->comm.mpiComm);
+    {
+      int nscale = 1;
+      platform->options.getArgs("MESH REFINEMENT SCALE", nscale);
+      if (nscale > 1) {
+        nelgt *= nscale;
+        nelgv *= nscale;
+      }
+    }
     const int NelemBenchmark = nelgv / platform->comm.mpiCommSize;
 
     bool verbose = platform->options.compareArgs("VERBOSE", "TRUE");
@@ -270,7 +286,7 @@ void registerMultigridLevelKernels(const std::string &section, int Nf, int N, in
 
   if (N == 1) {
     if (  platform->options.compareArgs(optionsPrefix + "MULTIGRID COARSE SOLVE", "TRUE") &&
-         !platform->options.compareArgs(optionsPrefix + "MULTIGRID COARSE SOLVE AND SMOOTH", "TRUE") ) { 
+         !platform->options.compareArgs(optionsPrefix + "MULTIGRID COARSE SOLVE AND SMOOTH", "TRUE") ) {
       return;
     }
   }

--- a/src/lib/nekrs.cpp
+++ b/src/lib/nekrs.cpp
@@ -212,6 +212,14 @@ void setup(MPI_Comm commg_in,
   {
     int nelgt, nelgv;
     re2::nelg(platform->options.getArgs("MESH FILE"), nelgt, nelgv, comm);
+    {
+      int nscale = 1;
+      options->getArgs("MESH REFINEMENT SCALE", nscale);
+      if (nscale > 1) {
+        nelgt *= nscale;
+        nelgv *= nscale;
+      }
+    }
     nekrsCheck(size > nelgv, platform->comm.mpiComm, EXIT_FAILURE, "%s\n", "MPI tasks > number of elements!");
   }
 

--- a/src/nekInterface/Makefile
+++ b/src/nekInterface/Makefile
@@ -9,14 +9,17 @@ USR_LFLAGS_:=$(shell echo $(USR_LFLAGS) | sed -E "s@-L$(left)[^ ]+$(right)@-Wl,-
 
 NI_LDFLAGS = $(LDFLAGS) -Wl,-rpath,. -L$(OBJDIR) -lnek5000 -ldl $(USR_LFLAGS_)
 
-$(OBJDIR)/nekInterface.o: $(NEKRS_NEKINTERFACE_DIR)/nekInterface.f $(LIB) 
-	$(FC) -c $(FL2) $< -o $@ 
+$(OBJDIR)/nekInterface.o: $(NEKRS_NEKINTERFACE_DIR)/nekInterface.f $(LIB)
+	$(FC) -c $(FL2) $< -o $@
+
+$(OBJDIR)/nekRefine.o: $(NEKRS_NEKINTERFACE_DIR)/nekRefine.f $(LIB)
+	$(FC) -c $(FL2) $< -o $@
 
 libnekInterface: lib$(CASENAME).so
 
-lib$(CASENAME).so: $(LIB) $(USRF) $(OBJDIR)/nekInterface.o
-	$(FC) $(FL2) -shared -o lib$(CASENAME).so $(USRF) $(OBJDIR)/nekInterface.o $(NI_LDFLAGS)
+lib$(CASENAME).so: $(LIB) $(USRF) $(OBJDIR)/nekInterface.o $(OBJDIR)/nekRefine.o
+	$(FC) $(FL2) -shared -o lib$(CASENAME).so $(USRF) $(OBJDIR)/nekInterface.o $(OBJDIR)/nekRefine.o $(NI_LDFLAGS)
 
 #.NOTPARALLEL:
 
-.PHONY: libnekInterface 
+.PHONY: libnekInterface

--- a/src/nekInterface/nekInterface.f
+++ b/src/nekInterface/nekInterface.f
@@ -197,11 +197,13 @@ c-----------------------------------------------------------------------
       endif
 #endif
 
+      call ifill(boundaryID, -1, 6*lelv)
+      call ifill(boundaryIDt, -1, 6*lelt)
+
       ifld_bId = 2
       if(ifflow) ifld_bId = 1
       do iel = 1,nelv
       do ifc = 1,2*ndim
-         boundaryID(ifc,iel) = -1
          if(bc(5,ifc,iel,ifld_bId).gt.0) then
            boundaryID(ifc,iel) = bc(5,ifc,iel,ifld_bId)
            idx = ibsearch(bIDMap, bIDMapSize, bc(5,ifc,iel,ifld_bId))
@@ -216,7 +218,6 @@ c-----------------------------------------------------------------------
       if(nelgt.ne.nelgv) then 
         do iel = 1,nelt
         do ifc = 1,2*ndim
-         boundaryIDt(ifc,iel) = -1
          if(bc(5,ifc,iel,2).gt.0) then
            boundaryIDt(ifc,iel) = bc(5,ifc,iel,2)
            idx = ibsearch(bIDtMap, bIDtMapSize, bc(5,ifc,iel,2))

--- a/src/nekInterface/nekInterface.f
+++ b/src/nekInterface/nekInterface.f
@@ -111,7 +111,7 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
-      subroutine nekf_setup(ifflow_in, 
+      subroutine nekf_setup(ifflow_in, refine, refineSize,
      $                      bIDMap, bIDMapSize, bIDtMap, bIDtMapSize,
      $                      npscal_in, idpss_in, p32, mpart, contol,
      $                      rho, mue, rhoCp, lambda, stsform) 
@@ -120,6 +120,9 @@ c-----------------------------------------------------------------------
       include 'TOTAL'
       include 'DOMAIN'
       include 'NEKINTF'
+
+      integer refineSize
+      integer refine(refineSize)
 
       integer bIDMapSize
       integer bIDtMapSize
@@ -250,6 +253,10 @@ c-----------------------------------------------------------------------
 
       if(nio.eq.0) write(6,*) 'call usrdat2'
       etime1 = dnekclock_sync()
+      do iref=1,refineSize
+        call usrdat2_oct(refine(iref))
+      enddo
+
       call usrdat2
       etime2 = dnekclock_sync()
       if(nio.eq.0) write(6,998) ' done :: usrdat2', etime2-etime1

--- a/src/nekInterface/nekInterfaceAdapter.cpp
+++ b/src/nekInterface/nekInterfaceAdapter.cpp
@@ -867,16 +867,16 @@ void buildNekInterface(int ldimt, int N, int np, setupAide &options)
       const std::string meshFile = options.getArgs("MESH FILE");
 
       re2::nelg(meshFile, nelgt, nelgv, MPI_COMM_SELF);
+      int lelt = (nelgt / np) + 3;
       {
         int nscale = 1;
         platform->options.getArgs("MESH REFINEMENT SCALE", nscale);
         if (nscale > 1) {
           nelgt *= nscale;
           nelgv *= nscale;
+          lelt *= nscale;
         }
       }
-
-      int lelt = (nelgt / np) + 3;
       if (lelt > nelgt) {
         lelt = nelgt;
       }

--- a/src/nekInterface/nekRefine.f
+++ b/src/nekInterface/nekRefine.f
@@ -1,0 +1,344 @@
+c-----------------------------------------------------------------------
+      subroutine usrdat2_oct(ncut) ! interface to oct-refine code
+
+c     Note that lelt and lelg need to be LARGE enough
+
+      include 'SIZE'
+      include 'TOTAL'
+
+      parameter(lxyz=lx1*ly1*lz1)
+      common /c_is1/ glo_num(lxyz*lelt)
+      integer*8 glo_num
+
+      ncut_o = ncut
+
+      call h_refine(glo_num,ncut_o)
+
+c     call outpost(xm1,ym1,zm1,pr,t,'   ')
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine interp_mat(jmat,zo,no,zi,ni,s,t)
+      real jmat(no,ni),zo(no),zi(ni),s(ni),t(ni)
+
+      call rone(s,ni)
+      do i=1,ni                ! Compute denominators ("alpha_i")
+         do j=1,i-1
+            s(i) = s(i)*(zi(i)-zi(j))
+         enddo
+         do j=i+1,ni
+            s(i) = s(i)*(zi(i)-zi(j))
+         enddo
+      enddo
+
+      do j=1,ni
+         a_j = 1./s(j)
+         do i=1,no
+            jmat(i,j) = a_j
+         enddo
+      enddo
+
+      call rone(s,ni)
+      call rone(t,ni)
+      do i=1,no
+         x=zo(i)
+         do j=2,ni
+            jm   = ni+1-j
+            s(j) = s(j-1 )*(x-zi(j-1))
+            t(jm)= t(jm+1)*(x-zi(jm+1))
+         enddo
+         do j=1,ni
+            jmat(i,j) = jmat(i,j)*s(j)*t(j)
+         enddo
+      enddo
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine get_rst_m1(xb,yb,zb,ncut,x1,y1,z1,pc,pt)
+
+c       call get_rst_m1(x0,y0,z0,ncut
+c    $                 ,xm1(1,1,1,e),ym1(1,1,1,e),zm1(1,1,1,e),pc,pt)
+
+      include 'SIZE'
+      include 'TOTAL'
+
+      real xb(lx1*ly1*lz1,ncut*ncut*ncut)
+     $    ,yb(lx1*ly1*lz1,ncut*ncut*ncut)
+     $    ,zb(lx1*ly1*lz1,ncut*ncut*ncut)
+
+      real x1(lx1*ly1*lz1),y1(lx1*ly1*lz1),z1(lx1*ly1*lz1)
+      real pc(lx1*lx1,ncut) ! Interpolation matrix
+      real pt(lx1*lx1,ncut) ! Interpolation matrix
+
+      common /qtmp0/ z_out(lx1),wk(lx1*lx1),wk2(lx1*lx1)
+
+c     if (pc(1,1).eq.0) then  ! Recompute interpolation matrices
+      if (lx1.gt.0)     then  ! Recompute interpolation matrices
+        dr = 2./ncut
+        do k=1,ncut
+          r0 = -1. + (k-1)*dr
+          do i=1,lx1
+            z_out(i) = r0 + dr*(zgm1(i,1)+1)/2.
+          enddo
+          call interp_mat(pc(1,k),z_out,lx1,zgm1,lx1,wk,wk2)
+          call transpose (pt(1,k),lx1,pc(1,k),lx1)
+        enddo
+      endif
+
+      if (ldim.eq.3) then
+
+       lc=0
+       do kc=1,ncut
+       do jc=1,ncut
+       do ic=1,ncut
+          lc=lc+1
+          call tensr3(xb(1,lc),lx1,x1,lx1,pc(1,ic),pt(1,jc),pt(1,kc),wk)
+          call tensr3(yb(1,lc),lx1,y1,lx1,pc(1,ic),pt(1,jc),pt(1,kc),wk)
+          call tensr3(zb(1,lc),lx1,z1,lx1,pc(1,ic),pt(1,jc),pt(1,kc),wk)
+       enddo
+       enddo
+       enddo
+
+      else ! 2D
+
+       lc=0
+       do jc=1,ncut
+       do ic=1,ncut
+          lc=lc+1
+          call tensr3(xb(1,lc),lx1,x1,lx1,pc(1,ic),pt(1,jc),pt(1,kc),wk)
+          call tensr3(yb(1,lc),lx1,y1,lx1,pc(1,ic),pt(1,jc),pt(1,kc),wk)
+       enddo
+       enddo
+
+      endif
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine elcopy(en,e)
+      include 'SIZE'
+      include 'TOTAL'
+
+c     ADD MORE ITEMS, as needed
+
+      integer e,en,eg
+
+      lxyz = lx1*ly1*lz1
+
+      call copy(xm1(1,1,1,en),xm1(1,1,1,e),lxyz)
+      call copy(ym1(1,1,1,en),ym1(1,1,1,e),lxyz)
+      call copy(zm1(1,1,1,en),zm1(1,1,1,e),lxyz)
+
+      do kf=0,ldimt1
+         call chcopy(cbc(1,en,kf),cbc(1,e,kf),18)
+         call copy  (bc(1,1,en,kf),bc(1,1,e,kf),30)
+      enddo
+      call icopy (boundaryID(1,en),boundaryID(1,e),6)
+      call icopy (boundaryIDt(1,en),boundaryIDt(1,e),6)
+
+      call copy  (curve(1,1,en),curve(1,1,e),72)
+      call chcopy(ccurve(1,en),ccurve(1,e),12)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine nek_init_2
+c
+      include 'SIZE'
+      include 'TOTAL'
+      include 'DOMAIN'
+c
+      include 'OPCTR'
+      include 'CTIMER'
+
+      real kwave2
+      logical ifemati
+
+      real rtest
+      integer itest
+      integer*8 itest8
+      character ctest
+      logical ltest 
+
+      common /c_is1/ glo_num(lx1 * ly1 * lz1, lelt)
+      common /ivrtx/ vertex((2 ** ldim) * lelt)
+      integer*8 glo_num, ngv
+      integer*8 vertex
+
+      if (nio.eq.0) then
+         write(6,12) 'nelgt/nelgv/lelt:',nelgt,nelgv,lelt
+         write(6,12) 'lx1/lx2/lx3/lxd: ',lx1,lx2,lx3,lxd
+ 12      format(1X,A,4I12)
+         write(6,*)
+      endif
+
+      instep=1             ! Check for zero steps
+      if (nsteps.eq.0 .and. fintim.eq.0.) instep=0
+
+      igeom = 2
+      call setup_topo      ! Setup domain topology  
+
+      if (ifmvbd) call setup_mesh_dssum ! Set mesh dssum (needs geom)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine h_refine(glo_num,ncut)
+
+c     Here we do an "ncut" refine:  ncut = 2 --> oct-refine (8x number of elements)
+c                                   ncut = 3 --> 27x number of elements
+c                                   ncut = 4 --> 64x number of elements
+
+      include 'SIZE'
+      include 'TOTAL'
+      include 'SCRCT'  ! For xyz() array
+
+      integer*8 glo_num(ncut+1,ncut+1,ncut*(ldim-2)+1,lelt)
+      integer e,eg,egn,el,en,er,es,et
+
+      parameter(lxyz=lx1*ly1*lz1,mxnew=500)
+      common /qcrmg/ x0(lxyz,mxnew),y0(lxyz,mxnew),z0(lxyz,mxnew)
+     $             , pc(lx1*lx1,mxnew),pt(lx1*lx1,mxnew)
+      real pc,pt
+
+      common /ivrtx/ vertex ((2**ldim),lelt)
+      integer*8 vertex
+      integer*8 ngv
+
+      integer ibuf(2)
+
+      integer isym2pre(8)   ! Symmetric-to-prenek vertex ordering
+      save    isym2pre
+      data    isym2pre / 1 , 2 , 4 , 3 , 5 , 6 , 8 , 7 /
+
+      nblk = ncut**ldim
+      nnew = nblk - 1
+      lxyc = 2**ldim
+      nvrt = ncut+1
+
+c     CHECK limit sizes 
+
+      call lim_chk(nblk,mxnew,'nblk ','mxnew',' h_refine ')
+
+      nelt_new = nblk*nelt+1 ! +1 for temporary storage
+      call lim_chk(nelt_new,lelt,'n_new','lelt ',' h_refine ')
+
+      nelgt_new = nblk*nelgt
+      call lim_chk(nelgt_new,lelg,'ngnew','lelg ',' h_refine ')
+
+      call rzero(pc,lx1*lx1)
+
+      call set_vert(glo_num,ngv,nvrt,nelt,vertex,.true.) ! Get new vertex set
+
+#if defined(DPROCMAP)
+      call dProcMapClearCache()
+#endif
+
+      do e=nelt,1,-1  ! REPLICATE EACH ELEMENT, working backward
+
+        eg = lglel(e)
+
+        call elcopy(lelt,e) ! Save current element
+
+        call get_rst_m1(x0,y0,z0,ncut
+     $                 ,xm1(1,1,1,e),ym1(1,1,1,e),zm1(1,1,1,e),pc,pt)
+
+
+        el = 0
+        en = nblk*(e -1)
+        egn= nblk*(eg-1)
+
+        net=ncut
+        if (ldim.eq.2) net=1
+        do et=1,net          ! ncut^ldim reps
+        do es=1,ncut
+        do er=1,ncut
+
+          el = el+1
+          en = en+1
+          egn= egn+1
+
+          call elcopy(en,lelt) ! Copy saved element e to en
+
+#if defined(DPROCMAP)
+          lglel(en) = egn
+          ibuf(1) = en
+          ibuf(2) = nid
+          call dProcmapPut(ibuf,2,0,eg)
+#else
+          lglel(en)  = egn
+          gllel(egn) = en      ! THIS PART MUST BE FIXED for scalability !
+          gllnid(eg) = nid
+#endif
+
+          call copy(xm1(1,1,1,en),x0(1,el),lxyz)
+          call copy(ym1(1,1,1,en),y0(1,el),lxyz)
+          call copy(zm1(1,1,1,en),z0(1,el),lxyz)
+
+c         Note - we need to update xc,yc,zc
+c         Note - we also should extract midside nodes.
+
+          k0=1 + (et-1)
+          j0=1 + (es-1)
+          i0=1 + (er-1)
+
+          nk = 1
+          if (ldim.eq.2) nk=0
+
+          lc = 0
+          do kc=0,nk
+          do jc=0,1
+          do ic=0,1
+             lc=lc+1
+             vertex(lc,en)=glo_num(i0+ic,j0+jc,k0+kc,e)
+
+             ii = 1 + ic*(lx1-1)
+             jj = 1 + jc*(ly1-1)
+             kk = 1 + kc*(lz1-1)
+             ipre=isym2pre(lc)
+             xc(ipre,en) = xm1(ii,jj,kk,en)
+             yc(ipre,en) = ym1(ii,jj,kk,en)
+             zc(ipre,en) = zm1(ii,jj,kk,en)
+
+             xyz(1,ipre,en)=xc(ipre,en)
+             xyz(2,ipre,en)=yc(ipre,en)
+             if (ldim.eq.3) xyz(3,ipre,en)=zc(ipre,en)
+
+          enddo
+          enddo
+          enddo
+
+          do kf=0,nfield
+              if (er.gt.1)    cbc(4,en,kf)='E  '  ! r-boundaries (face=4,2)
+              if (er.lt.ncut) cbc(2,en,kf)='E  '
+              if (es.gt.1)    cbc(1,en,kf)='E  '  ! s-boundaries (face=1,3)
+              if (es.lt.ncut) cbc(3,en,kf)='E  '
+              if (ldim.eq.3) then
+                 if (et.gt.1)    cbc(5,en,kf)='E  '  ! t-boundaries (face=5,6)
+                 if (et.lt.ncut) cbc(6,en,kf)='E  '
+              endif
+          enddo
+c         NOW, we have a periodicty problem to resolve...
+c         I think, however, that we already have the correct vertex topology
+              
+        enddo
+        enddo
+        enddo
+
+      enddo
+
+      nelt  = nblk*nelt
+      nelv  = nblk*nelv
+      nelgt = nblk*nelgt
+      nelgv = nblk*nelgv
+
+      do ifld=0,nfield
+         nelfld(ifld)=nblk*nelfld(ifld)
+      enddo
+
+      call nek_init_2  ! Reset some of the key arrays, etc.
+
+      return
+      end
+c-----------------------------------------------------------------------

--- a/src/nekInterface/nekRefine.f
+++ b/src/nekInterface/nekRefine.f
@@ -143,6 +143,22 @@ c     ADD MORE ITEMS, as needed
       return
       end
 c-----------------------------------------------------------------------
+      subroutine fczero(f,e)
+      include 'SIZE'
+      include 'TOTAL'
+
+      integer f,e
+
+      do kf=0,nfield
+          cbc(f,e,kf)='E  '
+          call rzero(bc(1,f,e,kf),5)
+      enddo
+      boundaryID(f,e)=0
+      boundaryIDt(f,e)=0
+
+      return
+      end
+c-----------------------------------------------------------------------
       subroutine nek_init_2
 c
       include 'SIZE'
@@ -309,16 +325,15 @@ c         Note - we also should extract midside nodes.
           enddo
           enddo
 
-          do kf=0,nfield
-              if (er.gt.1)    cbc(4,en,kf)='E  '  ! r-boundaries (face=4,2)
-              if (er.lt.ncut) cbc(2,en,kf)='E  '
-              if (es.gt.1)    cbc(1,en,kf)='E  '  ! s-boundaries (face=1,3)
-              if (es.lt.ncut) cbc(3,en,kf)='E  '
-              if (ldim.eq.3) then
-                 if (et.gt.1)    cbc(5,en,kf)='E  '  ! t-boundaries (face=5,6)
-                 if (et.lt.ncut) cbc(6,en,kf)='E  '
-              endif
-          enddo
+          if (er.gt.1)    call fczero(4,en)  ! r-boundaries (face=4,2)
+          if (er.lt.ncut) call fczero(2,en)
+          if (es.gt.1)    call fczero(1,en)  ! s-boundaries (face=1,3)
+          if (es.lt.ncut) call fczero(3,en)
+          if (ldim.eq.3) then
+             if (et.gt.1)    call fczero(5,en)  ! t-boundaries (face=5,6)
+             if (et.lt.ncut) call fczero(6,en)
+          endif
+
 c         NOW, we have a periodicty problem to resolve...
 c         I think, however, that we already have the correct vertex topology
               

--- a/src/nrs/nrs.cpp
+++ b/src/nrs/nrs.cpp
@@ -564,6 +564,14 @@ void nrs_t::init()
     int nelgt, nelgv;
     const std::string meshFile = platform->options.getArgs("MESH FILE");
     re2::nelg(meshFile, nelgt, nelgv, platform->comm.mpiComm);
+    {
+      int nscale = 1;
+      platform->options.getArgs("MESH REFINEMENT SCALE", nscale);
+      if (nscale > 1) {
+        nelgt *= nscale;
+        nelgv *= nscale;
+      }
+    }
 
     nekrsCheck(nelgt != nelgv && platform->options.compareArgs("MOVING MESH", "TRUE"),
                platform->comm.mpiComm,

--- a/src/nrs/registerNrsKernels.cpp
+++ b/src/nrs/registerNrsKernels.cpp
@@ -200,6 +200,14 @@ void registerNrsKernels(occa::properties kernelInfoBC)
       int nelgt, nelgv;
       const std::string meshFile = platform->options.getArgs("MESH FILE");
       re2::nelg(meshFile, nelgt, nelgv, platform->comm.mpiComm);
+      {
+        int nscale = 1;
+        platform->options.getArgs("MESH REFINEMENT SCALE", nscale);
+        if (nscale > 1) {
+          nelgt *= nscale;
+          nelgv *= nscale;
+        }
+      }
       const int NelemBenchmark = nelgv / platform->comm.mpiCommSize;
 
       bool verbose = platform->options.compareArgs("VERBOSE", "TRUE");


### PR DESCRIPTION
Features:
- High-order interpolation  
- On-the-fly refinement

Usage:
- Octant refinement: cut each elements into 8 elements
  ``` 
  [MESH]
  refine = 2
  ```
- Successive refinements: `1-> 8 -> 8*27`
  ``` 
  [MESH]
  refine = 2,3
  ```

Support cht

TODO?
- Safeguard: does it work at N=1? N=2?

Original subroutines come from Paul's h_refine.f