### PR TITLE
(drafted) Add MG layer for refined mesh

### DIFF
--- a/src/mesh/mesh.h
+++ b/src/mesh/mesh.h
@@ -102,6 +102,9 @@ struct mesh_t {
   int dim;
   int Nverts, Nfaces, NfaceVertices;
 
+  int uniform = 0;
+  int isRefine = 0;
+
   int Nbid;
 
   int cht;
@@ -260,7 +263,7 @@ struct mesh_t {
 };
 
 std::pair<mesh_t*, mesh_t*> createMesh(MPI_Comm comm, int N, int cubN, bool cht, occa::properties &kernelInfo);
-mesh_t *createMeshMG(mesh_t *_mesh, int Nc);
+mesh_t *createMeshMG(mesh_t *_mesh, int Nc, int isRefine = 0);
 
 occa::properties meshKernelProperties(int N);
 // serial sort

--- a/src/mesh/meshBasisHex3D.cpp
+++ b/src/mesh/meshBasisHex3D.cpp
@@ -31,12 +31,16 @@
 // ------------------------------------------------------------------------
 // HEX 3D NODES
 // ------------------------------------------------------------------------
-void NodesHex3D(int _N, dfloat *_r, dfloat *_s, dfloat *_t)
+void NodesHex3D(int _N, dfloat *_r, dfloat *_s, dfloat *_t, int uniform)
 {
   int _Nq = _N + 1;
 
   dfloat *r1D = (dfloat *)malloc(_Nq * sizeof(dfloat));
-  JacobiGLL(_N, r1D); // Gauss-Legendre-Lobatto nodes
+  if (unidorm) {
+    EquispacedNodes1D(_N, r1D);
+  } else {
+    JacobiGLL(_N, r1D); // Gauss-Legendre-Lobatto nodes
+  }
 
   // Tensor product
   for (int k = 0; k < _Nq; k++) {

--- a/src/mesh/meshGlobalIds.cpp
+++ b/src/mesh/meshGlobalIds.cpp
@@ -22,7 +22,7 @@ void meshNekParallelConnectNodes(mesh_t* mesh)
   dlong localNodeCount = mesh->Np * mesh->Nelements;
 
   mesh->globalIds = (hlong*) calloc(localNodeCount, sizeof(hlong));
-  hlong ngv = nek::set_glo_num(mesh->N + 1, mesh->cht);
+  hlong ngv = nek::set_glo_num(mesh->N + 1, mesh->Nelements, mesh->isRefine);
   for(dlong id = 0; id < localNodeCount; ++id)
     mesh->globalIds[id] = nekData.glo_num[id];
 }

--- a/src/mesh/meshLoadReferenceNodesHex3D.cpp
+++ b/src/mesh/meshLoadReferenceNodesHex3D.cpp
@@ -28,7 +28,7 @@
 #include "mesh3D.h"
 #define NODE_GEN
 
-void meshLoadReferenceNodesHex3D(mesh_t *mesh, int N, int cubN)
+void meshLoadReferenceNodesHex3D(mesh_t *mesh, int N, int cubN, int uniform)
 {
   mesh->N = N;
   mesh->Nq = N + 1;
@@ -51,7 +51,7 @@ void meshLoadReferenceNodesHex3D(mesh_t *mesh, int N, int cubN)
   mesh->r = (dfloat*) malloc(mesh->Np * sizeof(dfloat));
   mesh->s = (dfloat*) malloc(mesh->Np * sizeof(dfloat));
   mesh->t = (dfloat*) malloc(mesh->Np * sizeof(dfloat));
-  NodesHex3D(mesh->N, mesh->r, mesh->s, mesh->t);
+  NodesHex3D(mesh->N, mesh->r, mesh->s, mesh->t, uniform);
 
   mesh->faceNodes = (int*) malloc(mesh->Nfaces * mesh->Nfp * sizeof(int));
   FaceNodesHex3D(mesh->N, mesh->r, mesh->s, mesh->t, mesh->faceNodes);
@@ -59,10 +59,14 @@ void meshLoadReferenceNodesHex3D(mesh_t *mesh, int N, int cubN)
   //GLL quadrature
   mesh->gllz = (dfloat*) malloc((mesh->N + 1) * sizeof(dfloat));
   mesh->gllw = (dfloat*) malloc((mesh->N + 1) * sizeof(dfloat));
-  JacobiGLL(mesh->N, mesh->gllz, mesh->gllw);
+  if (uniform) {
+    EquispacedNodes1D(mesh->N, mesh->gllz, mesh->gllw);
+  } else {
+    JacobiGLL(mesh->N, mesh->gllz, mesh->gllw);
+  }
 
   mesh->D = (dfloat*) malloc(mesh->Nq * mesh->Nq * sizeof(dfloat));
-  Dmatrix1D(mesh->N, mesh->Nq, mesh->gllz, mesh->Nq, mesh->gllz, mesh->D);
+  Dmatrix1D(mesh->N, mesh->Nq, mesh->gllz, mesh->Nq, mesh->gllz, mesh->D); // TODO uniform? this is not used for now multilevel gMG
 
   mesh->DW = (dfloat*) malloc(mesh->Nq * mesh->Nq * sizeof(dfloat));
   DWmatrix1D(mesh->N, mesh->D, mesh->DW);

--- a/src/mesh/meshNekReader.cpp
+++ b/src/mesh/meshNekReader.cpp
@@ -34,7 +34,7 @@ void meshNekReaderHex3D(int N, mesh_t *mesh)
   const int faceMap[] = {1, 2, 3, 4, 0, 5};
 
   // generate element vertex numbering
-  mesh->Nnodes = nek::set_glo_num(2, mesh->cht);
+  mesh->Nnodes = nek::set_glo_num(2, mesh->Nelements, mesh->isRefine);
 
   mesh->EToV = (hlong *)calloc(mesh->Nelements * mesh->Nverts, sizeof(hlong));
   for (int e = 0; e < mesh->Nelements; ++e) {

--- a/src/mesh/meshPhysicalNodesHex3D.cpp
+++ b/src/mesh/meshPhysicalNodesHex3D.cpp
@@ -33,7 +33,7 @@ void meshPhysicalNodesHex3D(mesh_t *mesh)
   std::vector<dfloat> ym(mesh->Nlocal);
   std::vector<dfloat> zm(mesh->Nlocal);
 
-  nek::xm1N(xm.data(), ym.data(), zm.data(), mesh->N, mesh->Nelements);
+  nek::xm1N(xm.data(), ym.data(), zm.data(), mesh->N, mesh->Nelements, mesh->uniform);
 
   mesh->o_x =
     platform->device.malloc<dfloat>(mesh->Nlocal);

--- a/src/mesh/meshSetup.cpp
+++ b/src/mesh/meshSetup.cpp
@@ -333,10 +333,12 @@ std::pair<mesh_t*, mesh_t*> createMesh(MPI_Comm comm, int N, int cubN, bool cht,
   return {mesh, meshV};
 }
 
-mesh_t *createMeshMG(mesh_t *_mesh, int Nc)
+mesh_t *createMeshMG(mesh_t *_mesh, int Nc, int isRefine_)
 {
   mesh_t *mesh = new mesh_t();
   memcpy(mesh, _mesh, sizeof(mesh_t));
+  isRefine = isRefine_;
+  uniform = (isRefine) ? 1 : 0;
 
   const int cubN = 0;
   meshLoadReferenceNodesHex3D(mesh, Nc, cubN);

--- a/src/nekInterface/nekInterface.f
+++ b/src/nekInterface/nekInterface.f
@@ -808,22 +808,26 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
-      integer*8 function nekf_set_vert(nx, isTmsh)
+      integer*8 function nekf_set_vert(nx, nel, isRefine)
 
       include 'SIZE'
       include 'TOTAL'
       include 'NEKINTF'
 
-      integer npts, isTmsh
+      integer nx, nel, isRefine
 
+      common /ivrtx0/ vertex_orig ((2**ldim),lelt)
+      integer*8 vertex_orig
       common /ivrtx/ vertex ((2**ldim),lelt)
       integer*8 vertex
 
       integer*8 ngv
 
-      nel = nelt
-      if (isTmsh.eq.0) nel = nelv
-      call set_vert(glo_num,ngv,nx,nel,vertex,.false.)
+      if (isRefine.eq.0) then
+        call set_vert(glo_num,ngv,nx,nel,vertex,.false.)
+      else ! refined meshes use original vertex
+        call set_vert(glo_num,ngv,nx,nel,vertex_orig,.false.)
+      endif
 
       nekf_set_vert = ngv
 

--- a/src/nekInterface/nekInterfaceAdapter.hpp
+++ b/src/nekInterface/nekInterfaceAdapter.hpp
@@ -122,7 +122,7 @@ void writeFld(const std::string& filename,
               bool uniform = false);
 
 void finalize(void);
-void xm1N(dfloat *x, dfloat *y, dfloat *z, int Nq, dlong Nelements);
+void xm1N(dfloat *x, dfloat *y, dfloat *z, int Nq, dlong Nelements, int uniform = 0);
 long long int localElementIdToGlobal(int _id);
 int lglel(int e);
 int setup(int numberActiveFields);
@@ -138,7 +138,7 @@ int bcmap(int bid, int ifld);
 int globalElementIdToRank(long long id);
 int globalElementIdToLocal(long long id);
 
-long long set_glo_num(int npts, int isTMesh);
+long long set_glo_num(int npts, int nel, int isRefine);
 
 void bdfCoeff(dfloat *g0, dfloat *coeff, dfloat *dt, int order);
 void extCoeff(dfloat *coeff, dfloat *dt, int nAB, int nBDF);

--- a/src/nekInterface/nekRefine.f
+++ b/src/nekInterface/nekRefine.f
@@ -7,6 +7,7 @@ c     Note that lelt and lelg need to be LARGE enough
       include 'TOTAL'
 
       parameter(lxyz=lx1*ly1*lz1)
+
       common /c_is1/ glo_num(lxyz*lelt)
       integer*8 glo_num
 
@@ -277,6 +278,9 @@ c                                   ncut = 4 --> 64x number of elements
      $             , pc(lx1*lx1,mxnew),pt(lx1*lx1,mxnew)
       real pc,pt
 
+      common /ivrtx0/ vertex_orig ((2**ldim),lelt)
+      integer*8 vertex_orig
+
       common /ivrtx/ vertex ((2**ldim),lelt)
       integer*8 vertex
       integer*8 ngv
@@ -287,6 +291,18 @@ c                                   ncut = 4 --> 64x number of elements
       integer isym2pre(8)   ! Symmetric-to-prenek vertex ordering
       save    isym2pre
       data    isym2pre / 1 , 2 , 4 , 3 , 5 , 6 , 8 , 7 /
+
+      integer icalld
+      save icalld
+      data icalld / 0 /
+
+      if (icalld.eq.0) then
+         do i = (2**ldim)*nelt
+            vertex_orig(i,1) = vertex(i)
+         enddo
+         if (nio.eq.0) write(6,12) nelt
+ 13         format('h-refine: backup vertex into vertex_orig',I12)
+      endif
 
       nblk = ncut**ldim
       nnew = nblk - 1


### PR DESCRIPTION
Plan:

- MG levels
  - N=7, mesh_t (isRefine = 0)
  - N=3, mesh_t (isRefine = 0)
  - N=1, mesh_t (isRefine = 0)
  - N=2, mesh_t (isRefine = 1) (`Omega_h`) (equal to prev layer)
  - N=1, mesh_t (isRefine = 1) (`Omega_2h`) (new crs)

- `mesh_t`
  - Support `isRefine` and `uniform`. The latter for uniform spacing.
    This preserve tensor product interpolation between levels.
- `refine_t`, local work func + bridge between (isRefine = 0) and (isRefine = 1) 
  - pack/unpack
  - coarsening / prolongation
  - interpolation (no need?)
